### PR TITLE
Patch/fix too aggressive force text

### DIFF
--- a/formulation/templatetags/formulation.py
+++ b/formulation/templatetags/formulation.py
@@ -140,14 +140,15 @@ def field(context, field, widget=None, **kwargs):
             (force_text(k), v)
             for k, v in field_data['choices']
         ]
+
         # Normalize the value [django.forms.widgets.Select.render_options]
         value = field_data['value']()
         if value is None:  # don't force_text these
             field_data['value'] = value
+        elif isinstance(value, (list, tuple)):
+            field_data['value'] = [force_text(v) for v in value]
         else:
-            field_data['value'] = ([force_text(v) for v in value]
-                                   if isinstance(value, (list, tuple))
-                                   else force_text(value))
+            field_data['value'] = force_text(value)
 
     # Allow supplied values to override field data
     field_data.update(kwargs)

--- a/formulation/templatetags/formulation.py
+++ b/formulation/templatetags/formulation.py
@@ -142,9 +142,12 @@ def field(context, field, widget=None, **kwargs):
         ]
         # Normalize the value [django.forms.widgets.Select.render_options]
         value = field_data['value']()
-        field_data['value'] = ([force_text(v) for v in value]
-                              if isinstance(value, (list, tuple))
-                              else force_text(value))
+        if value is None:  # don't force_text these
+            field_data['value'] = value
+        else:
+            field_data['value'] = ([force_text(v) for v in value]
+                                   if isinstance(value, (list, tuple))
+                                   else force_text(value))
 
     # Allow supplied values to override field data
     field_data.update(kwargs)


### PR DESCRIPTION
This replaces PR #33.

I added a test that fails in the current master branch, and it passes with my patch. I just check the value for None and don't force_text it in that case. I'm not sure if I should check 'False' too (tests pass with check for both None and False), but I think that False is only relevant for BooleanField.

Either way, in my specific use case I have a hidden ModelChoiceField that's now failing in production for anonymous users because that field is not initialized for them, and thus rendered as ... value="None" ... Not a critical page at this time, but I think this is a real issue.
